### PR TITLE
[Mr. Minou's case] Add `offset` as fittable parameter, and allow user to specify their own databank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 modules/test.py
 test.py
+.DS_Store
+test/sample_LTE_Tgas.py
+sample_LTE_Tgas.py

--- a/JSON_test_dir/test_JSON_file.json
+++ b/JSON_test_dir/test_JSON_file.json
@@ -10,7 +10,8 @@
     "mole_fraction": 0.96,
     "path_length": 1,
     "offset": "-0.2 nm",
-    "slit": "1 nm"
+    "slit": "1 nm",
+    "databank": "hitemp"
   },
   "fit": {
     "Tgas": 1000

--- a/modules/fitting_module.py
+++ b/modules/fitting_module.py
@@ -112,9 +112,17 @@ def get_conditions(
     if "offset" in fit_params:
 
         offset_value, offset_unit = fit_params.pop("offset").split()
+        if offset_unit == "cm-1":
+            offset_unitName = "cm1"
+        elif offset_unit == "nm":
+            offset_unitName = "nm"
+        else:
+            raise ValueError(f"Unrecognizable offset unit {offset_unit}. Only \"nm\" and \"cm-1\" are accepted.")
+
+        # The reason for all the mess above is, LMFIT does not accept parameter name with hyphen like cm-1. So I remove the hyphen.
 
         # Get numerical value only, and add unit to name for later identification
-        fit_params[f"offset{offset_unit}"] = float(offset_value)
+        fit_params[f"offset{offset_unitName}"] = float(offset_value)
 
     # Put every fit parameter into Parameters, with the default bounding range
 
@@ -124,7 +132,7 @@ def get_conditions(
 
         if (param == "mole_fraction"):
             init_bound = [0, 1]
-        elif ("offset" in param):       # Either "offsetnm" or "offsetcm-1"
+        elif ("offset" in param):       # Either "offsetnm" or "offsetcm1"
             init_bound = [-1, 1]
         else:
             init_bound = [
@@ -161,7 +169,7 @@ def get_conditions(
                     # Destroy the original key
                     bounds.pop("Tvib")
 
-        # Deal with "offset", especially now the offset parameter is either "offsetnm" or "offsetcm-1"
+        # Deal with "offset", especially now the offset parameter is either "offsetnm" or "offsetcm1"
 
         if "offset" in bounds:
 
@@ -170,8 +178,8 @@ def get_conditions(
             if "offsetnm" in params:
                 bounds["offsetnm"] = bound_offset
 
-            if "offsetcm-1" in params:
-                bounds["offsetcm-1"] = bound_offset
+            if "offsetcm1" in params:
+                bounds["offsetcm1"] = bound_offset
 
 
         # Set user-defined bounding ranges
@@ -510,6 +518,9 @@ def fit_spectrum(
             if "offset" in name:                # "offset" detected
                 offset_value = float(param.value)
                 offset_unit = name[6 : ]
+                # Deal with "cm1"
+                if offset_unit == "cm1":
+                    offset_unit = "cm-1"
             else:                               # Other parameters not related to offset
                 fit_show[name] = float(param.value)
         fit_show["name"] = "best_fit"

--- a/modules/model_LTE.py
+++ b/modules/model_LTE.py
@@ -57,7 +57,7 @@ def residual_LTE(params, conditions, s_data, sf, log, verbose = True):
     # Load initial values of fit parameters
     ignore_keys = [
         "offsetnm",
-        "offsetcm-1",
+        "offsetcm1",
     ]
     kwargs = {}
     for param in params:
@@ -71,8 +71,8 @@ def residual_LTE(params, conditions, s_data, sf, log, verbose = True):
     if "offsetnm" in params:
         offset_value = float(params["offsetnm"])
         s_model = s_model.offset(offset_value, "nm")
-    if "offsetcm-1" in params:
-        offset_value = float(params["offsetcm-1"])
+    if "offsetcm1" in params:
+        offset_value = float(params["offsetcm1"])
         s_model = s_model.offset(offset_value, "cm-1")
 
 

--- a/modules/model_LTE.py
+++ b/modules/model_LTE.py
@@ -55,12 +55,26 @@ def residual_LTE(params, conditions, s_data, sf, log, verbose = True):
     # GENERATE LTE SPECTRUM BASED ON THOSE PARAMETERS
 
     # Load initial values of fit parameters
+    ignore_keys = [
+        "offsetnm",
+        "offsetcm-1",
+    ]
     kwargs = {}
     for param in params:
-        kwargs[param] = float(params[param])
+        if param not in ignore_keys:
+            kwargs[param] = float(params[param])
     
     # Spectrum calculation
     s_model = sf.eq_spectrum(**kwargs)
+
+    # Deal with "offset"
+    if "offsetnm" in params:
+        offset_value = float(params["offsetnm"])
+        s_model = s_model.offset(offset_value, "nm")
+    if "offsetcm-1" in params:
+        offset_value = float(params["offsetcm-1"])
+        s_model = s_model.offset(offset_value, "cm-1")
+
 
 
     # FURTHER REFINE THE MODELED SPECTRUM BEFORE CALCULATING DIFF

--- a/modules/model_nonLTE.py
+++ b/modules/model_nonLTE.py
@@ -55,9 +55,14 @@ def residual_NonLTE(params, conditions, s_data, sf, log, verbose = True):
     # GENERATE NON-LTE SPECTRUM BASED ON THOSE PARAMETERS
 
     # Load initial values of fit parameters
+    ignore_keys = [
+        "offsetnm",
+        "offsetcm-1",
+    ]
     kwargs = {}
     for param in params:
-        kwargs[param] = float(params[param])
+        if param not in ignore_keys:
+            kwargs[param] = float(params[param])
 
     # Deal with the case of multiple Tvib temperatures
     if "Tvib0" in kwargs:       # There is trace of a "Tvib fragmentation" before
@@ -70,6 +75,14 @@ def residual_NonLTE(params, conditions, s_data, sf, log, verbose = True):
     
     # Spectrum calculation
     s_model = sf.non_eq_spectrum(**kwargs)
+
+    # Deal with "offset"
+    if "offsetnm" in params:
+        offset_value = float(params["offsetnm"])
+        s_model = s_model.offset(offset_value, "nm")
+    if "offsetcm-1" in params:
+        offset_value = float(params["offsetcm-1"])
+        s_model = s_model.offset(offset_value, "cm-1")
 
 
     # FURTHER REFINE THE MODELED SPECTRUM BEFORE CALCULATING DIFF

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ tuna           # to generate visual/interactive performance profiles
 tables  # for pandas to HDF5 export
 habanero  # CrossRef API to retrieve data from doi
 lmfit
+numdifftools

--- a/sample_notebooks/sample_LTE-with-JSON_Tgas.ipynb
+++ b/sample_notebooks/sample_LTE-with-JSON_Tgas.ipynb
@@ -87,17 +87,17 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.10 64-bit",
+      "display_name": "Python 3.8.9 64-bit",
       "language": "python",
       "name": "python3"
     },
     "language_info": {
       "name": "python",
-      "version": "3.8.10"
+      "version": "3.8.9"
     },
     "vscode": {
       "interpreter": {
-        "hash": "a4868653bb6f8972e87e4c446ab8a445a15b25dedb8594cc74c480f8152ea86a"
+        "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
       }
     }
   },

--- a/sample_notebooks/sample_LTE_Tgas-molfrac.ipynb
+++ b/sample_notebooks/sample_LTE_Tgas-molfrac.ipynb
@@ -71,7 +71,8 @@
         "    \"pressure\" : 2,             # Partial pressure of gas, in \"bar\" unit.\n",
         "    \"path_length\" : 1,          # Experimental path length, in \"cm\" unit.\n",
         "    \"slit\" : \"1 nm\",            # Experimental slit, must be a blank space separating slit amount and unit.\n",
-        "    \"offset\" : \"-0.2 nm\"        # Experimental offset, must be a blank space separating offset amount and unit.\n",
+        "    \"offset\" : \"-0.2 nm\",       # Experimental offset, must be a blank space separating offset amount and unit.\n",
+        "    \"databank\" : \"hitemp\"       # Databank used for the spectrum calculation.\n",
         "}\n",
         "\n",
         "# List of parameters to be fitted.\n",
@@ -126,17 +127,17 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.10 64-bit",
+      "display_name": "Python 3.8.9 64-bit",
       "language": "python",
       "name": "python3"
     },
     "language_info": {
       "name": "python",
-      "version": "3.8.10"
+      "version": "3.8.9"
     },
     "vscode": {
       "interpreter": {
-        "hash": "a4868653bb6f8972e87e4c446ab8a445a15b25dedb8594cc74c480f8152ea86a"
+        "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
       }
     }
   },

--- a/sample_notebooks/sample_LTE_Tgas.ipynb
+++ b/sample_notebooks/sample_LTE_Tgas.ipynb
@@ -20,11 +20,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "bE1Il73CoMGO"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cloning into 'RADIS-Spectrum-Fitting-Benchmark'...\n",
+            "remote: Enumerating objects: 357, done.\u001b[K\n",
+            "remote: Counting objects: 100% (86/86), done.\u001b[K (24/86)\u001b[K\n",
+            "remote: Compressing objects: 100% (56/56), done.\u001b[K\n",
+            "remote: Total 357 (delta 28), reused 67 (delta 26), pack-reused 271\u001b[K\n",
+            "Receiving objects: 100% (357/357), 219.75 MiB | 684.00 KiB/s, done.\n",
+            "Resolving deltas: 100% (120/120), done.\n"
+          ]
+        }
+      ],
       "source": [
         "import os\n",
         "from os import path\n",
@@ -70,7 +84,8 @@
         "    \"pressure\" : 10,            # Partial pressure of gas, in \"bar\" unit.\n",
         "    \"path_length\" : 1,          # Experimental path length, in \"cm\" unit.\n",
         "    \"slit\" : \"1 nm\",            # Experimental slit, must be a blank space separating slit amount and unit.\n",
-        "    \"offset\" : \"-0.2 nm\"        # Experimental offset, must be a blank space separating offset amount and unit.\n",
+        "    \"offset\" : \"-0.2 nm\",       # Experimental offset, must be a blank space separating offset amount and unit.\n",
+        "    \"databank\" : \"hitemp\"       # Databank used for the spectrum calculation. Must be specified.\n",
         "}\n",
         "\n",
         "# List of parameters to be fitted.\n",
@@ -124,7 +139,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.10 64-bit",
+      "display_name": "Python 3.8.9 64-bit",
       "language": "python",
       "name": "python3"
     },
@@ -138,11 +153,11 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.10"
+      "version": "3.8.9"
     },
     "vscode": {
       "interpreter": {
-        "hash": "a4868653bb6f8972e87e4c446ab8a445a15b25dedb8594cc74c480f8152ea86a"
+        "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
       }
     }
   },

--- a/test/sample_LTE_Tgas.py
+++ b/test/sample_LTE_Tgas.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from modules.fitting_module import fit_spectrum
 from radis import load_spec
 
@@ -18,7 +16,8 @@ experimental_conditions = {
     "pressure" : 10,            # Partial pressure of gas, in "bar" unit.
     "path_length" : 1,          # Experimental path length, in "cm" unit.
     "slit" : "1 nm",            # Experimental slit, must be a blank space separating slit amount and unit.
-    "offset" : "-0.2 nm"        # Experimental offset, must be a blank space separating offset amount and unit.
+    "offset" : "-0.2 nm",       # Experimental offset, must be a blank space separating offset amount and unit.
+    "databank" : "hitemp"       # Databank used for the spectrum calculation.
 }
 
 # List of parameters to be fitted.


### PR DESCRIPTION
This pull request is to implement 2 features, as suggested by Mr. @minouHub :
- Allow `offset` to be fitted. Previously, as `offset` and `slit` are not parameters of `calc_spectrum()`, but instead post-calculation convolution steps, so I did not include them as fit parameters. Now `offset` is included. As for `slit`, according to Mr. @minouHub, usually the users know their FTIR spectrometer's stats, and measure `slit` separately, so I have yet implemeted `slit` as fittable parameter.
- Now the users can specify the databank to be fetched into SpectrumFactory with `fetch_databank`, by stating it directly in the script.

The changes can be seen in below script:
```python
from modules.fitting_module import fit_spectrum
from radis import load_spec
import os

# Load experimental spectrum. You can prepare yours, or fetch one of them in the ground-truth folder like below.
os.chdir('/Users/tranhuunhathuy/Documents/GitHub/RADIS-Spectrum-Fitting-Benchmark')
s_experimental = load_spec("./data/LTE/ground-truth/synth-NH3-1-500-2000-cm-1-P10-t1000-v-r-mf0.01-p1-sl1nm.spec")

# Experimental conditions which will be used for spectrum modeling. Basically, these are known ground-truths.
experimental_conditions = {
    "molecule" : "NH3",         # Molecule ID
    "isotope" : "1",            # Isotope ID, can have multiple at once
    "wmin" : 1000,              # Starting wavelength/wavenumber to be cropped out from the original experimental spectrum.
    "wmax" : 1050,              # Ending wavelength/wavenumber for the cropping range.
    "wunit" : "cm-1",           # Accompanying unit of those 2 wavelengths/wavenumbers above.
    "mole_fraction" : 0.01,     # Species mole fraction, from 0 to 1.
    "pressure" : 10,            # Partial pressure of gas, in "bar" unit.
    "path_length" : 1,          # Experimental path length, in "cm" unit.
    "slit" : "1 nm",            # Experimental slit, must be a blank space separating slit amount and unit.
    #"offset" : "-0.2 nm",       # Experimental offset, must be a blank space separating offset amount and unit.
    "databank" : "hitran"       # Databank used for the spectrum calculation. Must be stated.
}

# List of parameters to be fitted.
fit_parameters = {
    "Tgas" : 700,               # Fit parameter, accompanied by its initial value.
    "offset" : "0.1 nm"         # Experimental offset, must be a blank space separating offset amount and unit.
}

# List of bounding ranges applied for those fit parameters above.
bounding_ranges = {
    "Tgas" : [600, 2000],       # Bounding ranges for each fit parameter stated above. You can skip this step, but not recommended.
    "offset" : [-0.3, 0.3]
}

# Fitting pipeline setups.
fit_properties = {
    "method" : "lbfgsb",        # Preferred fitting method from the 17 confirmed methods of LMFIT stated in week 4 blog. By default, "leastsq".
    "fit_var" : "radiance",     # Spectral quantity to be extracted for fitting process, such as "radiance", "absorbance", etc.
    "normalize" : False,        # Either applying normalization on both spectra or not.
    "max_loop" : 150,           # Max number of loops allowed. By default, 100.
    "tol" : 1e-10               # Fitting tolerance, only applicable for "lbfgsb" method.
}


# Conduct the fitting process!
s_best, result, log = fit_spectrum(
    s_exp = s_experimental,
    fit_params = fit_parameters,
    bounds = bounding_ranges,
    model = experimental_conditions,
    pipeline = fit_properties
)


# Now investigate the log

print("\nResidual history: \n")
print(log["residual"])

print("\nFitted values history: \n")
for fit_val in log["fit_vals"]:
    print(fit_val)

print("\nTotal fitting time: ")
print(log["time_fitting"], end = " s\n")
```

And the result seems promising, with `Tgas = 992.043` (ground-truth as 1000) and `offset = -0.1885` (ground-truth as -0.2 nm).

<img width="1410" alt="Screen Shot 2022-08-25 at 18 21 24" src="https://user-images.githubusercontent.com/29034232/186627861-2613b262-873c-422e-a6e7-48376f989d26.png">
